### PR TITLE
Add check on length of entropy in cleanInputEntropy

### DIFF
--- a/pkg/mnemonic/utils.go
+++ b/pkg/mnemonic/utils.go
@@ -23,6 +23,12 @@ func cleanInputEntropy(entropy string) ([]byte, error) {
 		return nil, newEntropyIsEmptyError()
 	}
 
+	// make sure that the entropy is small enough,
+	// so that the rest of the function can't cause int overflow
+	if len(entropy) > upperENTBound / 4 {
+		return nil, newENTNotInRangeError()
+	}
+
 	// FIXME test on huge inputs
 	bytes, err := hex.DecodeString(entropy)
 	if err != nil {


### PR DESCRIPTION
Resolves issue [#5 ](https://github.com/quapka/PA193_mnemonic_aller/issues/5). The function `getBinaryLength` remains unchanged, but the problem is fixed in `cleanInputEntropy`, which is responsible for checking the validity of input entropy.